### PR TITLE
manually calling node-gyp is not needed anymore with recent npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "node": ">= 0.7 || 0.8"
   }
 , "scripts": {
-    "preinstall": "node-gyp configure && node-gyp build"
-  , "test": "mocha"
+    "test": "mocha"
   }
 }
 


### PR DESCRIPTION
npm will run node-gyp when it finds a binding.gyp in the module, so manually calling node-gyp is not needed anymore.

on a side note, I think the wscript file can be removed, since node-waf has been removed in favour of node-gyp
