### PR TITLE
Doesn't install on Node v0.8.14

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,5 +2,14 @@
   'targets': [ {
     'target_name': 'crash'
   , 'sources': [ 'src/crash.cc' ]
-  } ]
+  , 'cflags!': [ '-fno-exceptions' ]
+  , 'cflags_cc!': [ '-fno-exceptions' ]
+  , 'conditions': [
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
+      	}
+      }]
+  	]
+  }]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
   , 'conditions': [
       ['OS=="mac"', {
         'xcode_settings': {
-          'GCC_ENABLE_CPP_EXCEPTIONS': 'NO',        # -fno-exceptions
+          'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',        # -fno-exceptions
       	}
       }]
   	]


### PR DESCRIPTION
Trying to install, I get this

```
$ npm install crash
npm WARN package.json application-name@0.0.1 No README.md file found!
npm http GET https://registry.npmjs.org/crash
npm http 304 https://registry.npmjs.org/crash

> crash@2.0.2 install /Users/jweis/mysrc/scratch/express_sample/node_modules/crash
> node-gyp rebuild

  CXX(target) Release/obj.target/crash/src/crash.o
../src/crash.cc:10:3: error: cannot use 'throw' with exceptions disabled
  throw "Crash!";
  ^
1 error generated.
make: *** [Release/obj.target/crash/src/crash.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/jweis/nvm/v0.8.14/lib/node_modules/node-gyp/lib/build.js:232:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:99:17)
gyp ERR! stack     at Process._handle.onexit (child_process.js:678:10)
gyp ERR! System Darwin 11.4.0
gyp ERR! command "node" "/Users/jweis/nvm/v0.8.14/bin/node-gyp" "rebuild"
gyp ERR! cwd /Users/jweis/mysrc/scratch/express_sample/node_modules/crash
gyp ERR! node -v v0.8.14
gyp ERR! node-gyp -v v0.7.3
gyp ERR! not ok 
npm ERR! crash@2.0.2 install: `node-gyp rebuild`
npm ERR! `sh "-c" "node-gyp rebuild"` failed with 1
npm ERR! 
npm ERR! Failed at the crash@2.0.2 install script.
npm ERR! This is most likely a problem with the crash package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls crash
npm ERR! There is likely additional logging output above.

npm ERR! System Darwin 11.4.0
npm ERR! command "/Users/jweis/nvm/v0.8.14/bin/node" "/Users/jweis/nvm/v0.8.14/bin/npm" "install" "crash"
npm ERR! cwd /Users/jweis/mysrc/scratch/express_sample
npm ERR! node -v v0.8.14
npm ERR! npm -v 1.1.65
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/jweis/mysrc/scratch/express_sample/npm-debug.log
npm ERR! not ok code 0
```

I'm running 0.8.14:

```
$ node -v
v0.8.14
```

I'm using it with nvm:

```
$ which node
/Users/jweis/nvm/v0.8.14/bin/node
```
